### PR TITLE
Code fixes

### DIFF
--- a/src/PlantsIdentifierAPI/Controllers/PlantsController.cs
+++ b/src/PlantsIdentifierAPI/Controllers/PlantsController.cs
@@ -46,7 +46,7 @@ namespace PlantsIdentifierAPI.Controllers
 		[ProducesResponseType(200)]
 		//Returns this because the Plant may not exist
 		[ProducesResponseType(404)]
-		public async Task<ActionResult<PlantDTO>> Get(string ID)
+		public async Task<ActionResult<PlantDTO>> Get(Guid ID)
 		{
 			try
 			{

--- a/src/PlantsIdentifierAPI/Interfaces/IPlantsServices.cs
+++ b/src/PlantsIdentifierAPI/Interfaces/IPlantsServices.cs
@@ -9,7 +9,7 @@ namespace PlantsIdentifierAPI.Interfaces
 {
 	public interface IPlantsServices
 	{
-		Task<PlantDTO> GetPlant(string ID);
+		Task<PlantDTO> GetPlant(Guid ID);
 		IEnumerable<PlantDTO> GetAll();
 		Task<PlantDTO> GetPlantByCommonName(string commonName);
 		void SavePlant(PlantDTO plant);

--- a/src/PlantsIdentifierAPI/Services/PlantsServices.cs
+++ b/src/PlantsIdentifierAPI/Services/PlantsServices.cs
@@ -27,7 +27,7 @@ namespace PlantsIdentifierAPI.Services
             for (var i = 0; i < plants.Count(); i++)
                 yield return _mapper.Map<PlantDTO>(plants[i]);
         }
-        public async Task<PlantDTO> GetPlant(string ID)
+        public async Task<PlantDTO> GetPlant(Guid ID)
         {
             var plant = await _plantsContext.Plant.FirstOrDefaultAsync(p => p.ID.Equals(ID));
             return _mapper.Map<PlantDTO>(plant);

--- a/tests/PlantsIdentifierAPI.UnitTests/Controllers/PlantsControllerTests.cs
+++ b/tests/PlantsIdentifierAPI.UnitTests/Controllers/PlantsControllerTests.cs
@@ -55,11 +55,11 @@ namespace PlantsIdentifierAPI.UnitTests.Controllers
 			//Arrange
 			var guidToSearchFor = Guid.NewGuid();			
 			var mockRepo = new Mock<IPlantsServices>();
-			mockRepo.Setup(repo => repo.GetPlant(It.IsAny<string>())).Returns(Task.FromResult(Mock.Of<PlantDTO>(p => p.ID == guidToSearchFor)));
+			mockRepo.Setup(repo => repo.GetPlant(It.IsAny<Guid>())).Returns(Task.FromResult(Mock.Of<PlantDTO>(p => p.ID == guidToSearchFor)));
 			var controller = new PlantsController(mockRepo.Object);
 
 			//Act
-			var result = await controller.Get(guidToSearchFor.ToString());
+			var result = await controller.Get(guidToSearchFor);
 
 			var contentResult = result.Result as OkObjectResult;
 			var plant = (PlantDTO)contentResult.Value;
@@ -79,7 +79,7 @@ namespace PlantsIdentifierAPI.UnitTests.Controllers
 			var controller = new PlantsController(mockRepo.Object);
 
 			//Act
-			var result = await controller.Get(Guid.NewGuid().ToString());
+			var result = await controller.Get(Guid.NewGuid());
 			var contentResult = result.Result as NotFoundObjectResult;
 
 			//Assert

--- a/tests/PlantsIdentifierAPI.UnitTests/PlantsIdentifierAPI.UnitTests.csproj
+++ b/tests/PlantsIdentifierAPI.UnitTests/PlantsIdentifierAPI.UnitTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EntityFrameworkCoreMock.Moq" Version="1.0.0.9" />
+    <PackageReference Include="EntityFrameworkCoreMock.Moq" Version="1.0.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Moq" Version="4.10.0" />
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="2.1.1"/>
+    <PackageReference Include="coverlet.msbuild" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/PlantsIdentifierAPI.UnitTests/Services/PlantsServicesTests.cs
+++ b/tests/PlantsIdentifierAPI.UnitTests/Services/PlantsServicesTests.cs
@@ -1,16 +1,12 @@
-﻿using AutoMapper;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoMapper;
 using EntityFrameworkCoreMock;
 using Microsoft.EntityFrameworkCore;
-using Moq;
-using PlantsIdentifierAPI.DTOS;
-using PlantsIdentifierAPI.Interfaces;
+using PlantsIdentifierAPI.Helpers;
 using PlantsIdentifierAPI.Models;
 using PlantsIdentifierAPI.Services;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace PlantsIdentifierAPI.UnitTests.Services
@@ -18,12 +14,12 @@ namespace PlantsIdentifierAPI.UnitTests.Services
     public class PlantsServicesTests
     {
         readonly DbContextMock<PlantsContext> _dbContextMock;
-        readonly Mock<IMapper> _mapperMock;
+        readonly IMapper _mapper;
 
         public PlantsServicesTests()
         {
             _dbContextMock = new DbContextMock<PlantsContext>(DefaultOptions);
-            _mapperMock = new Mock<IMapper>();
+            _mapper = new MapperConfiguration(c => c.AddProfile<AutoMapperProfile>()).CreateMapper();
         }
 
         public DbContextOptions<PlantsContext> DefaultOptions { get; } = new DbContextOptionsBuilder<PlantsContext>().Options;
@@ -33,7 +29,7 @@ namespace PlantsIdentifierAPI.UnitTests.Services
         {
             //Arrange
             var plantsInitialDBSet = _dbContextMock.CreateDbSetMock(x => x.Plant, new[] { new Plant { } });
-            var service = new PlantsServices(_dbContextMock.Object, _mapperMock.Object);
+            var service = new PlantsServices(_dbContextMock.Object, _mapper);
 
             //Act
             var result = service.GetAll();
@@ -49,7 +45,7 @@ namespace PlantsIdentifierAPI.UnitTests.Services
         {
             //Arrange
             var plantsInitialDBSet = _dbContextMock.CreateDbSetMock(x => x.Plant);
-            var service = new PlantsServices(_dbContextMock.Object, _mapperMock.Object);
+            var service = new PlantsServices(_dbContextMock.Object, _mapper);
 
             //Act
             var result = service.GetAll();
@@ -64,37 +60,37 @@ namespace PlantsIdentifierAPI.UnitTests.Services
         {
             //Arrange
             var plantsInitialDBSet = _dbContextMock.CreateDbSetMock(x => x.Plant);
-            var service = new PlantsServices(_dbContextMock.Object, _mapperMock.Object);
+            var service = new PlantsServices(_dbContextMock.Object, _mapper);
 
             //Act
-            var result = await service.GetPlant(Moq.It.IsAny<string>());
+            var result = await service.GetPlant(Moq.It.IsAny<Guid>());
 
             //Assert
             Assert.Null(result);
         }
 
-        //[Fact]
-        //public async Task Plants_GetPlantByID_ReturnsOk()
-        //{
-        //    //Arrange
-        //    var plantID = Guid.NewGuid();
-        //    var plantsInitialDBSet = _dbContextMock.CreateDbSetMock(x => x.Plant, new[] { new Plant { ID = plantID } });
-        //    var service = new PlantsServices(_dbContextMock.Object, _mapperMock.Object);
+        [Fact]
+        public async Task Plants_GetPlantByID_ReturnsOk()
+        {
+            //Arrange
+            var plantID = Guid.NewGuid();
+            var plantsInitialDBSet = _dbContextMock.CreateDbSetMock(x => x.Plant, new[] { new Plant { ID = plantID } });
+            var service = new PlantsServices(_dbContextMock.Object, _mapper);
 
-        //    //Act
-        //    var result = await service.GetPlant(plantID.ToString());
+            //Act
+            var result = await service.GetPlant(plantID);
 
-        //    //Assert
-        //    Assert.NotNull(result);
-        //    Assert.Equal(result.ID, plantID);
-        //}
+            //Assert
+            Assert.NotNull(result);
+            Assert.Equal(result.ID, plantID);
+        }
 
         [Fact]
         public async Task Plants_GetPlantByCommonName_ReturnsNull()
         {
             //Arrange
             var plantsInitialDBSet = _dbContextMock.CreateDbSetMock(x => x.Plant);
-            var service = new PlantsServices(_dbContextMock.Object, _mapperMock.Object);
+            var service = new PlantsServices(_dbContextMock.Object, _mapper);
 
             //Act
             var result = await service.GetPlantByCommonName(Moq.It.IsAny<string>());


### PR DESCRIPTION
2 problems with your code:
* You can't do `p => p.ID.Equals(ID)` where `p.ID` is a `Guid` and `ID` is a `string`, this will always be false
* You need to use the real AutoMapperProfile instead of a mock, otherwise the result of the `Map` will always be `null`

This PR fixes both of these issues, causing the test `Plants_GetPlantByID_ReturnsOk` to succeed.